### PR TITLE
feat: Allow fractional quantities and improve density input

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -4,7 +4,7 @@ from app.database import get_db_connection
 from app.units import (
     convert_to_base, needs_conversion_prompt, get_conversion_prompt_html,
     get_base_unit_type, get_base_unit, get_new_ingredient_conversion_prompt_html,
-    convert_units, format_fraction, convert_from_base
+    convert_units, format_fraction, convert_from_base, parse_quantity
 )
 
 def get_all_units():
@@ -40,7 +40,7 @@ def pantry():
 def add_ingredient():
     ingredient_name = request.form['ingredient_name'].strip().lower()
     try:
-        quantity = float(request.form.get('quantity', 0))
+        quantity = parse_quantity(request.form.get('quantity', '0'))
     except (ValueError, TypeError):
         quantity = 0
     unit = request.form.get('unit', '').strip().lower()
@@ -494,7 +494,7 @@ def add_ingredient_to_meal(meal_id):
 
         ingredient_id = ingredient['id']
         try:
-            ingredient_quantity = float(quantity)
+            ingredient_quantity = parse_quantity(quantity)
         except ValueError:
             return "Invalid quantity."
 

--- a/app/templates/_converter_modal.html
+++ b/app/templates/_converter_modal.html
@@ -130,6 +130,18 @@ function openModal() {
   document.getElementById('unit-converter-modal').style.display = 'block';
 }
 
+function openModalAndTab(tabName) {
+    openModal();
+    // Use a small timeout to ensure the modal is visible before clicking the tab
+    setTimeout(() => {
+        // Find the button that controls the target tab and click it
+        const tabButton = Array.from(document.querySelectorAll('.tablinks')).find(btn => btn.textContent.trim() === tabName);
+        if (tabButton) {
+            tabButton.click();
+        }
+    }, 50);
+}
+
 function closeModal() {
   document.getElementById('unit-converter-modal').style.display = 'none';
 }

--- a/app/templates/recipe_editor.html
+++ b/app/templates/recipe_editor.html
@@ -41,5 +41,7 @@
 
         <p><a href="/recipes" class="button">Back to Recipe Manager</a></p>
     </div>
+
+    {% include '_converter_modal.html' %}
 </body>
 </html>


### PR DESCRIPTION
This commit introduces two main improvements:

1.  **Fractional Quantity Parsing:** A new `parse_quantity` function has been added to `app/units.py` to handle fractional and mixed number inputs for ingredient quantities (e.g., "1/2", "1 3/4"). The routes for adding ingredients to the pantry and to recipes now use this function, allowing users to enter measurements in a more natural way.

2.  **Enhanced Density Input:** The prompt for entering the density of a new ingredient has been improved. It now includes a link to open a density calculator modal. This allows users to easily convert common measurements (e.g., "1 cup = 120g") into the required g/mL format without leaving the page. The converter modal has been added to all relevant pages to support this workflow.