### PR TITLE
fix: Ensure converter modal is available on all relevant pages

### DIFF
--- a/app/templates/pantry.html
+++ b/app/templates/pantry.html
@@ -57,5 +57,7 @@
             {% endwith %}
         </div>
     </div>
+
+    {% include '_converter_modal.html' %}
 </body>
 </html>


### PR DESCRIPTION
This commit fixes a JavaScript ReferenceError for `openModalAndTab` that occurred when adding a new ingredient from the pantry page.

The `_converter_modal.html` template, which contains the necessary JavaScript functions, was not included in `pantry.html`. This commit adds the include statement to `pantry.html`, ensuring the modal and its associated functions are loaded correctly.

This change is part of the larger feature for improving quantity and density input.