### PR TITLE
feat: Allow changing ingredient units and defining density

### DIFF
--- a/app/templates/_update_density_prompt.html
+++ b/app/templates/_update_density_prompt.html
@@ -1,0 +1,22 @@
+<li class="ingredient-item edit-mode">
+    <div id="conversion-prompt" class="conversion-prompt">
+        <h4>Update Ingredient: Density Needed</h4>
+        <p>You are changing <strong>{{ ingredient.name }}</strong> to a unit of mass or volume. To allow for future conversions, please provide its density.</p>
+        <p class="small-text">Don't know the density in g/ml? <button type="button" class="link-button" onclick="openModalAndTab('Density')">Calculate it here</button>.</p>
+        <form hx-post="/update_ingredient_details/{{ ingredient.id }}" hx-target="closest li" hx-swap="outerHTML">
+            <input type="hidden" name="new_name" value="{{ new_name }}">
+            <input type="hidden" name="new_quantity" value="{{ new_quantity }}">
+            <input type="hidden" name="new_unit" value="{{ new_unit }}">
+            <input type="hidden" name="view_name" value="{{ view_name }}">
+
+            <label for="density">Density (grams per milliliter):</label>
+            <input type="number" name="density_g_ml" id="density" step="any" required placeholder="e.g., 1 for water, 0.53 for flour">
+
+            <div class="form-buttons">
+                <button type="submit">Save Changes</button>
+                <button type="button" hx-get="/ingredient/{{ ingredient.id }}?view_name={{ view_name or 'pantry' }}" hx-target="closest li" hx-swap="outerHTML" class="cancel-btn">Cancel</button>
+            </div>
+        </form>
+        <p class="small-text">Why is this needed? The application stores all convertible ingredients by a base unit (grams or milliliters) for accuracy. Providing a density (g/mL) allows the system to correctly handle both weight and volume units for this ingredient.</p>
+    </div>
+</li>


### PR DESCRIPTION
This change addresses the issue where ingredients, particularly those added via the batch-add feature, were "stuck" with 'unit' as their unit.

The key changes include:
- The ingredient edit form now allows selecting any unit, enabling users to change an ingredient's type (e.g., from 'count' to 'mass').
- When changing an ingredient to a mass or volume type for the first time, the user is prompted to enter a density (g/ml). This is crucial for enabling mass-to-volume conversions.
- A new route and template have been added to handle the density prompt workflow seamlessly within the UI.
- The `edit_ingredient` route has been significantly enhanced to handle these new unit-changing scenarios, including updating the ingredient's `base_unit`, `base_unit_type`, and `density_g_ml` in the database.
- Existing density information is retained if an ingredient is switched back to a 'count' type, preserving data for future use.