### PR TITLE
feat: Improve recipe measurements and cooking mode UI

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,9 @@
 from flask import Flask
+from app.units import format_fraction
 
 app = Flask(__name__)
+
+# Register custom Jinja filter
+app.jinja_env.filters['format_fraction'] = format_fraction
 
 from app import routes

--- a/app/templates/_meal_ingredients_list.html
+++ b/app/templates/_meal_ingredients_list.html
@@ -3,7 +3,7 @@
     {% for item in meal_ingredients %}
     <li class="ingredient-item">
         <div class="ingredient-display">
-            <span>{{ item.name }} - <strong>{{ '%.2f'|format(item.display_quantity) }}</strong></span>
+            <span>{{ item.name }} - <strong>{{ item.display_quantity | format_fraction }}</strong></span>
 
             <form class="unit-selector-form">
                 <select name="unit"

--- a/app/templates/cooking_mode.html
+++ b/app/templates/cooking_mode.html
@@ -32,15 +32,15 @@
             <ul class="recipe-checklist">
                 {% for item in recipe_items %}
                 <li>
-                    <input type="checkbox" name="ingredient_used" value="{{ item.ingredient.id }}_{{ item.required_quantity }}" checked>
+                    <input type="checkbox" name="ingredient_used" value="{{ item.ingredient.id }}_{{ item.required_quantity }}">
                     <span class="ingredient-name">{{ item.ingredient.name }}</span>
                     -
-                    <span class="quantity-required">{{ "%.2f"|format(item.required_quantity) }} {{ item.ingredient.base_unit }} required</span>
+                    <span class="quantity-required">{{ item.required_quantity | format_fraction }} {{ item.ingredient.base_unit }} required</span>
 
                     {% if item.in_stock %}
-                        <span class="status-tag in-stock">✅ In Stock ({{ "%.2f"|format(item.pantry_quantity) }} {{ item.ingredient.base_unit }})</span>
+                        <span class="status-tag in-stock">✅ In Stock ({{ item.pantry_quantity | format_fraction }} {{ item.ingredient.base_unit }})</span>
                     {% elif item.pantry_quantity > 0 %}
-                        <span class="status-tag low-stock">⚠️ Low Stock ({{ "%.2f"|format(item.pantry_quantity) }} {{ item.ingredient.base_unit }})</span>
+                        <span class="status-tag low-stock">⚠️ Low Stock ({{ item.pantry_quantity | format_fraction }} {{ item.ingredient.base_unit }})</span>
                     {% else %}
                         <span class="status-tag out-of-stock">❌ Out of Stock</span>
                     {% endif %}

--- a/app/templates/recipe_editor.html
+++ b/app/templates/recipe_editor.html
@@ -31,7 +31,7 @@
                     <div id="search-results-for-recipe"></div>
                 </div>
 
-                <input type="number" step="any" name="quantity" placeholder="Quantity" required>
+                <input type="text" name="quantity" placeholder="Quantity" required>
                 <input type="text" name="unit" placeholder="Unit (e.g., cup, g, oz)" required>
                 <button type="submit" class="button-primary">Add to Recipe</button>
             </form>


### PR DESCRIPTION
This commit introduces two main improvements to the user experience.

First, it allows for the use of common fractions and mixed numbers (e.g., "1 1/8") in recipe creation. The quantity input field has been changed from a number type to a text type. The display of these quantities throughout the app, including the recipe editor and cooking mode, now uses a custom filter to show fractions instead of decimals, making recipes easier to read.

Second, the checkboxes in the cooking mode are now unchecked by default. This provides a cleaner starting state for the user when they begin a cooking session.