### PR TITLE
fix(templates): Correct typo in cooking_mode.html

### DIFF
--- a/app/templates/cooking_mode.html
+++ b/app/templates/cooking_mode.html
@@ -30,7 +30,7 @@
                 {% if item.in_stock %}
                     <span class="status-tag in-stock">✅ In Stock ({{ item.display_quantity_pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
                 {% elif item.pantry_quantity_base > 0 %}
-                    <span class="status-tag low-stock">⚠️ Low Stock ({{ item.display_quantity_p pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
+                    <span class="status-tag low-stock">⚠️ Low Stock ({{ item.display_quantity_pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
                 {% else %}
                     <span class="status-tag out-of-stock">❌ Out of Stock</span>
                 {% endif %}


### PR DESCRIPTION
Fixes a `jinja2.exceptions.TemplateSyntaxError` that occurred when rendering the cooking mode page. The variable `item.display_quantity_p pantry` was a typo and has been corrected to `item.display_quantity_pantry`.