### PR TITLE
fix(templates): Correct template syntax and htmx navigation

### DIFF
--- a/app/templates/_meals_list.html
+++ b/app/templates/_meals_list.html
@@ -4,8 +4,8 @@
         <li>
             <span class="meal-name">{{ meal.name }}</span>
             <div class="meal-actions">
-                <a href="/meal/{{ meal.id }}" class="button">Cook</a>
-                <a href="/recipe/{{ meal.id }}" class="button">Manage</a>
+                <a href="/meal/{{ meal.id }}" hx-get="/meal/{{ meal.id }}" hx-target="#content" hx-swap="innerHTML" class="button">Cook</a>
+                <a href="/recipe/{{ meal.id }}" hx-get="/recipe/{{ meal.id }}" hx-target="#content" hx-swap="innerHTML" class="button">Manage</a>
                 <button hx-delete="/delete_meal/{{ meal.id }}" hx-target="closest li" hx-swap="outerHTML" hx-confirm="Are you sure you want to delete this meal?" class="button-danger">
                     Delete
                 </button>

--- a/app/templates/cooking_mode.html
+++ b/app/templates/cooking_mode.html
@@ -30,7 +30,7 @@
                 {% if item.in_stock %}
                     <span class="status-tag in-stock">✅ In Stock ({{ item.display_quantity_pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
                 {% elif item.pantry_quantity_base > 0 %}
-                    <span class="status-tag low-stock">⚠️ Low Stock ({{ item.display_quantity_p pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
+                    <span class="status-tag low-stock">⚠️ Low Stock ({{ item.display_quantity_pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
                 {% else %}
                     <span class="status-tag out-of-stock">❌ Out of Stock</span>
                 {% endif %}


### PR DESCRIPTION
This commit includes two fixes:

1.  Corrects a typo in `app/templates/cooking_mode.html` that caused a `jinja2.exceptions.TemplateSyntaxError`. The variable `item.display_quantity_p pantry` has been corrected to `item.display_quantity_pantry`.

2.  Adds explicit `hx-get`, `hx-target="#content"`, and `hx-swap` attributes to the 'Cook' and 'Manage' links in `app/templates/_meals_list.html`. This prevents an `htmx:targetError` during navigation by ensuring that partial content is always loaded into the correct container, preserving the main page structure.