### PR TITLE
fix(templates): Resolve multiple htmx navigation and template errors

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -900,7 +900,9 @@ def meal_page(meal_id):
     meal = conn.execute("SELECT * FROM meals WHERE id = ?", (meal_id,)).fetchone()
     conn.close()
     meal_ingredients = get_meal_ingredients(meal_id)
-    return render_template('meal.html', meal=meal, meal_ingredients=meal_ingredients)
+    if 'HX-Request' in request.headers:
+        return render_template('meal.html', meal=meal, meal_ingredients=meal_ingredients)
+    return render_template('index.html', page_content=render_template('meal.html', meal=meal, meal_ingredients=meal_ingredients))
 
 @app.route('/search_ingredients_for_cooking', methods=['POST'])
 def search_ingredients_for_cooking():

--- a/app/templates/_meals_list.html
+++ b/app/templates/_meals_list.html
@@ -4,8 +4,8 @@
         <li>
             <span class="meal-name">{{ meal.name }}</span>
             <div class="meal-actions">
-                <a href="/meal/{{ meal.id }}" class="button">Cook</a>
-                <a href="/recipe/{{ meal.id }}" class="button">Manage</a>
+                <a href="/meal/{{ meal.id }}" hx-get="/meal/{{ meal.id }}" hx-target="#content" hx-swap="innerHTML" class="button">Cook</a>
+                <a href="/recipe/{{ meal.id }}" hx-get="/recipe/{{ meal.id }}" hx-target="#content" hx-swap="innerHTML" class="button">Manage</a>
                 <button hx-delete="/delete_meal/{{ meal.id }}" hx-target="closest li" hx-swap="outerHTML" hx-confirm="Are you sure you want to delete this meal?" class="button-danger">
                     Delete
                 </button>

--- a/app/templates/cooking_mode.html
+++ b/app/templates/cooking_mode.html
@@ -30,7 +30,7 @@
                 {% if item.in_stock %}
                     <span class="status-tag in-stock">✅ In Stock ({{ item.display_quantity_pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
                 {% elif item.pantry_quantity_base > 0 %}
-                    <span class="status-tag low-stock">⚠️ Low Stock ({{ item.display_quantity_p pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
+                    <span class="status-tag low-stock">⚠️ Low Stock ({{ item.display_quantity_pantry | format_fraction }} {{ item.ingredient.display_unit }})</span>
                 {% else %}
                     <span class="status-tag out-of-stock">❌ Out of Stock</span>
                 {% endif %}

--- a/app/templates/meal.html
+++ b/app/templates/meal.html
@@ -1,41 +1,29 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ meal.name }}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
-</head>
-<body>
-    <div class="container">
-        <h1>{{ meal.name }}</h1>
+<div class="container">
+    <h1>{{ meal.name }}</h1>
 
-        <!-- Ingredients in this meal -->
-        <div id="meal-ingredients-list">
-            <h4>Ingredients</h4>
-            <ul class="meal-ingredients">
-                {% for item in meal_ingredients %}
-                <li>
-                    <span>{{ item.name }} - {{ item.pretty_quantity }}</span>
-                </li>
-                {% else %}
-                <li>No ingredients in this recipe yet.</li>
-                {% endfor %}
-            </ul>
-        </div>
-
-        <hr>
-
-        <!-- Start Cooking Form -->
-        <form action="/start_cooking_session" method="POST" target="_blank">
-            <input type="hidden" name="meal_id" value="{{ meal.id }}">
-            <label for="portion">Portion:</label>
-            <input type="number" name="portion" value="1" min="0.5" step="0.5" placeholder="Portion">
-            <button type="submit" class="button-primary">Start Cooking</button>
-        </form>
-
-        <p><a href="/recipes" class="button">Back to Recipe Manager</a></p>
+    <!-- Ingredients in this meal -->
+    <div id="meal-ingredients-list">
+        <h4>Ingredients</h4>
+        <ul class="meal-ingredients">
+            {% for item in meal_ingredients %}
+            <li>
+                <span>{{ item.name }} - {{ item.display_quantity | format_fraction }} {{ item.display_unit }}</span>
+            </li>
+            {% else %}
+            <li>No ingredients in this recipe yet.</li>
+            {% endfor %}
+        </ul>
     </div>
-</body>
-</html>
+
+    <hr>
+
+    <!-- Start Cooking Form -->
+    <form hx-post="/start_cooking_session" hx-target="#content" hx-swap="innerHTML">
+        <input type="hidden" name="meal_id" value="{{ meal.id }}">
+        <label for="portion">Portion:</label>
+        <input type="number" name="portion" value="1" min="0.5" step="0.5" placeholder="Portion">
+        <button type="submit" class="button-primary">Start Cooking</button>
+    </form>
+
+    <p><a href="/recipes" hx-get="/recipes" hx-target="#content" hx-swap="innerHTML" class="button">Back to Recipe Manager</a></p>
+</div>


### PR DESCRIPTION
This commit addresses a series of cascading issues related to htmx navigation and template rendering.

1.  Corrects a `TemplateSyntaxError` in `cooking_mode.html` by fixing a typo in a variable name.

2.  Fixes the root cause of multiple `htmx:targetError` events by refactoring `meal.html` into a proper partial template. The full HTML boilerplate was removed, and its form and links were updated to use explicit htmx attributes (`hx-post`, `hx-target`, etc.).

3.  Updates the `/meal/<int:meal_id>` route in `routes.py` to correctly handle htmx requests, serving the `meal.html` partial for htmx requests and embedding it in `index.html` for full page loads.

4.  Adds explicit `hx-target` attributes to the navigation links in `_meals_list.html` to prevent `hx-boost` from replacing the entire page body, which preserved the integrity of the main page structure.