### PR TITLE
feat: Add portion multiplier to recipe manager

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -185,6 +185,21 @@ ul.meals-list li:hover {
     gap: 8px;
     flex-shrink: 0;
     flex-wrap: wrap;
+    align-items: center;
+}
+
+.portion-multiplier {
+    width: 70px !important;
+    padding: 10px;
+    margin-bottom: 0;
+    text-align: center;
+    -moz-appearance: textfield; /* Firefox */
+}
+
+.portion-multiplier::-webkit-outer-spin-button,
+.portion-multiplier::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
 }
 
 li.ingredient-item {

--- a/app/templates/_meals_list.html
+++ b/app/templates/_meals_list.html
@@ -4,8 +4,9 @@
         <li>
             <span class="meal-name">{{ meal.name }}</span>
             <div class="meal-actions">
-                <form hx-post="/start_cooking_session" hx-target="#content" hx-swap="innerHTML" style="display: inline;">
+                <form hx-post="/start_cooking_session" hx-target="#content" hx-swap="innerHTML" style="display: flex; align-items: center; gap: 5px;">
                     <input type="hidden" name="meal_id" value="{{ meal.id }}">
+                    <input type="number" name="portion" value="1.0" min="0.5" step="0.5" class="portion-multiplier">
                     <button type="submit" class="button">Cook</button>
                 </form>
                 <a href="/recipe/{{ meal.id }}" hx-get="/recipe/{{ meal.id }}" hx-target="#content" hx-swap="innerHTML" class="button">Manage</a>


### PR DESCRIPTION
This commit re-introduces the portion multiplier to the meals list in the recipe manager.

- Adds a number input field to the left of the "Cook" button for each meal.
- The input allows for 0.5 intervals, with a minimum of 0.5 and a default of 1.0.
- Adds CSS to style the new input field for a clean and consistent look.

The backend already supports the 'portion' parameter, so no changes were required in the routes.