### PR TITLE
Fix ingredient selection and filter reset issues

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -963,7 +963,15 @@ def search_ingredients_for_recipe(meal_id):
 def select_ingredient():
     ingredient_name = request.form['ingredient_name']
     meal_id = request.form['meal_id']
-    return f'<input id="ingredient-search-input" type="search" name="q" value="{ingredient_name}" placeholder="Search for an ingredient to add..." hx-post="/search_ingredients_for_recipe/{meal_id}" hx-trigger="keyup changed delay:500ms, search" hx-target="#search-results-for-recipe" hx-swap="innerHTML">'
+    # The main returned element replaces the search input.
+    # The div with hx-swap-oob will be swapped "out of band", clearing the search results.
+    return f'''<input id="ingredient-search-input" type="search" name="q" value="{ingredient_name}"
+                   placeholder="Search for an ingredient to add..."
+                   hx-post="/search_ingredients_for_recipe/{meal_id}"
+                   hx-trigger="keyup changed delay:500ms, search"
+                   hx-target="#search-results-for-recipe"
+                   hx-swap="innerHTML">
+               <div id="search-results-for-recipe" hx-swap-oob="true"></div>'''
 
 @app.route('/meal/<int:meal_id>')
 def meal_page(meal_id):

--- a/app/templates/recipe_manager.html
+++ b/app/templates/recipe_manager.html
@@ -13,7 +13,7 @@
 
 <!-- Filter Meals Form -->
 <h2>Filter Meals by Ingredients</h2>
-<form hx-post="/filter_meals" hx-target="#meals-list-container" hx-swap="innerHTML">
+<form id="filter-form" hx-post="/filter_meals" hx-target="#meals-list-container" hx-swap="innerHTML">
     <div class="filter-grid">
         {% for category, ingredients_in_category in ingredients_by_category.items() %}
             <div class="filter-category-group">
@@ -28,7 +28,16 @@
     </div>
     <div class="form-buttons">
         <button type="submit" class="button-primary">Filter Meals</button>
-        <button type="button" hx-post="/filter_meals" hx-target="#meals-list-container" hx-swap="innerHTML" hx-include="[value='any']" name="ingredient_ids" value="any" class="button-secondary">Reset Filters</button>
+        <button type="button"
+                hx-post="/filter_meals"
+                hx-target="#meals-list-container"
+                hx-swap="innerHTML"
+                name="ingredient_ids"
+                value="any"
+                class="button-secondary"
+                onclick="document.querySelectorAll('#filter-form select').forEach(s => s.value = '');">
+            Reset Filters
+        </button>
     </div>
 </form>
 


### PR DESCRIPTION
This commit addresses two UI issues:

1.  When adding an ingredient to a recipe, selecting an ingredient from the search results now correctly populates the input field and clears the search results dropdown. This is achieved by using an htmx out-of-band swap to clear the results div.

2.  In the recipe manager, the ingredient filter can now be reset. An onclick handler has been added to the 'Reset Filters' button to clear the selection from the ingredient filter dropdowns.