### PR TITLE
feat: Implement recipe import from text

### DIFF
--- a/app/importer_service.py
+++ b/app/importer_service.py
@@ -1,0 +1,79 @@
+import ollama
+import json
+
+def import_recipe_from_text(text: str) -> dict:
+    """
+    Uses a multi-modal model to extract recipe data from a block of text.
+
+    Args:
+        text: A string containing the recipe.
+
+    Returns:
+        A dictionary with the extracted recipe data, conforming to a specific JSON schema.
+        Returns an empty dictionary if parsing fails.
+    """
+    prompt = f"""
+    You are a recipe parsing assistant. Your task is to extract the recipe name,
+    a list of ingredients (with quantity, unit, and name), and the instructions
+    from the provided text.
+    Return the output as a single, valid JSON object. Do not include any explanatory
+    text or markdown formatting before or after the JSON object.
+
+    The JSON object should have the following structure:
+    {{
+      "recipe_name": "string",
+      "ingredients": [
+        {{
+          "quantity": "string",
+          "unit": "string",
+          "name": "string"
+        }}
+      ],
+      "instructions": "string"
+    }}
+
+    Here is the recipe text:
+    ---
+    {text}
+    ---
+    """
+
+    try:
+        # It's a good practice to check if the model is available.
+        # For this implementation, we assume 'llava' is running.
+        # A more robust solution might involve checking available models.
+        response = ollama.chat(
+            model='llava',
+            messages=[{'role': 'user', 'content': prompt}],
+            options={'temperature': 0.1} # Lower temperature for more deterministic output
+        )
+
+        # The response content should be the JSON string.
+        response_text = response['message']['content']
+
+        # Clean up the response to get only the JSON part.
+        # Models sometimes add markdown backticks around the JSON.
+        if response_text.startswith("```json"):
+            response_text = response_text[7:]
+        if response_text.endswith("```"):
+            response_text = response_text[:-3]
+
+        response_text = response_text.strip()
+
+        # Parse the JSON string into a Python dictionary.
+        data = json.loads(response_text)
+
+        # Basic validation of the structure
+        if "recipe_name" in data and "ingredients" in data and "instructions" in data:
+            return data
+        else:
+            print("Error: Parsed JSON is missing required keys.")
+            return {{}}
+
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON from model response: {e}")
+        print(f"Raw response was: {response['message']['content']}")
+        return {{}}
+    except Exception as e:
+        print(f"An unexpected error occurred while calling the Ollama API: {e}")
+        return {{}}

--- a/app/routes.py
+++ b/app/routes.py
@@ -8,6 +8,7 @@ from app.units import (
     get_base_unit_type, get_base_unit, get_new_ingredient_conversion_prompt_html,
     convert_units, format_fraction, convert_from_base, parse_quantity
 )
+from app.importer_service import import_recipe_from_text
 
 def get_all_units():
     # These are hardcoded for consistency in the UI
@@ -1038,6 +1039,135 @@ def update_pantry():
         return f"<h4>Error: {e}</h4><p>Could not update pantry.</p>"
     finally:
         if conn: conn.close()
+
+@app.route('/import_recipe_process', methods=['POST'])
+def import_recipe_process():
+    recipe_text = request.form.get('recipe_text', '')
+    if not recipe_text:
+        return "No recipe text provided.", 400
+
+    recipe_data = import_recipe_from_text(recipe_text)
+
+    if not recipe_data:
+        return "Could not parse recipe. Please check the format.", 500
+
+    conn = get_db_connection()
+    all_ingredients_raw = conn.execute("SELECT id, name FROM ingredients").fetchall()
+    all_ingredients_map = {ing['name']: ing['id'] for ing in all_ingredients_raw}
+    all_ingredient_names = list(all_ingredients_map.keys())
+
+    for ingredient in recipe_data.get('ingredients', []):
+        # 1. Fuzzy match against existing ingredients
+        ingredient_name = ingredient.get('name', '').lower()
+        if ingredient_name and all_ingredient_names:
+            best_match = process.extractOne(ingredient_name, all_ingredient_names)
+            if best_match and best_match[1] > 80:
+                ingredient['suggestion_id'] = all_ingredients_map[best_match[0]]
+            else:
+                ingredient['suggestion_id'] = None
+        else:
+            ingredient['suggestion_id'] = None
+
+        # 2. Check if a density prompt will be needed if it's a new ingredient
+        ingredient['needs_density_prompt'] = False
+        if not ingredient['suggestion_id']: # It's a potential new ingredient
+            unit = ingredient.get('unit', '').lower()
+            unit_type = get_base_unit_type(unit)
+            if unit_type in ['mass', 'volume']:
+                ingredient['needs_density_prompt'] = True
+
+    # Get a list of all ingredients for the dropdowns
+    all_ingredients_for_dropdown = conn.execute("SELECT id, name FROM ingredients ORDER BY name").fetchall()
+    conn.close()
+
+    return render_template(
+        'recipe_import_review.html',
+        recipe_data=recipe_data,
+        all_ingredients=all_ingredients_for_dropdown
+    )
+
+@app.route('/save_imported_recipe', methods=['POST'])
+def save_imported_recipe():
+    conn = get_db_connection()
+    try:
+        with conn:
+            # 1. Create the new meal
+            recipe_name = request.form.get('recipe_name')
+            instructions = request.form.get('instructions')
+            if not recipe_name:
+                return "Recipe name is required.", 400
+
+            cursor = conn.cursor()
+            cursor.execute("INSERT INTO meals (name, instructions) VALUES (?, ?)", (recipe_name, instructions))
+            meal_id = cursor.lastrowid
+
+            # 2. Process ingredients
+            ingredient_ids = request.form.getlist('ingredient_id')
+            quantities = request.form.getlist('ingredient_quantity')
+            units = request.form.getlist('ingredient_unit')
+
+            for i in range(len(ingredient_ids)):
+                ing_id_val = ingredient_ids[i]
+                quantity_str = quantities[i]
+                unit = units[i].strip().lower()
+
+                try:
+                    quantity = parse_quantity(quantity_str)
+                except ValueError:
+                    continue # Skip invalid quantities
+
+                final_ingredient_id = None
+                if ing_id_val.startswith('_new_'):
+                    new_ing_name = ing_id_val[5:].strip().lower()
+                    existing = conn.execute("SELECT id FROM ingredients WHERE name = ?", (new_ing_name,)).fetchone()
+                    if existing:
+                        final_ingredient_id = existing['id']
+                    else:
+                        # This is a new ingredient, check for density data
+                        density_field_name = f"density_{new_ing_name.replace(' ', '_')}"
+                        density_str = request.form.get(density_field_name)
+
+                        base_unit_type = get_base_unit_type(unit) or 'count'
+                        base_unit = get_base_unit(base_unit_type)
+                        density_to_save = None
+
+                        if density_str:
+                            try:
+                                density_to_save = float(density_str)
+                                # If density is provided, it must be a mass/volume type.
+                                # The base unit will be 'g' for consistency.
+                                base_unit_type = 'mass'
+                                base_unit = 'g'
+                            except (ValueError, TypeError):
+                                density_to_save = None # Ignore invalid density values
+
+                        cursor.execute(
+                            "INSERT INTO ingredients (name, quantity, base_unit, base_unit_type, density_g_ml) VALUES (?, ?, ?, ?, ?)",
+                            (new_ing_name, 0, base_unit, base_unit_type, density_to_save)
+                        )
+                        final_ingredient_id = cursor.lastrowid
+                else:
+                    final_ingredient_id = int(ing_id_val)
+
+                # 3. Add to meal_ingredients
+                if final_ingredient_id:
+                    conn.execute(
+                        "INSERT INTO meal_ingredients (meal_id, ingredient_id, quantity, unit) VALUES (?, ?, ?, ?)",
+                        (meal_id, final_ingredient_id, quantity, unit)
+                    )
+
+        # Redirect to the new recipe's editor page
+        response = make_response()
+        response.headers['HX-Redirect'] = f'/recipe/{meal_id}'
+        return response
+
+    except Exception as e:
+        print(f"Error saving imported recipe: {e}")
+        return "Error saving recipe.", 500
+    finally:
+        if conn:
+            conn.close()
+
 
 @app.route('/recipes')
 def recipes():

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -507,3 +507,44 @@ li.ingredient-item:hover {
     padding-left: 10px;
     border-left: 3px solid var(--secondary-color);
 }
+
+/* Recipe Import Review Styles */
+.ingredient-review-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 15px;
+    padding: 10px;
+    border: 1px solid var(--light-grey-color);
+    border-radius: var(--border-radius);
+}
+
+.ingredient-review-item select {
+    flex: 2;
+    min-width: 150px;
+}
+
+.ingredient-review-item input {
+    margin-bottom: 0; /* Override default form input margin */
+}
+
+.ingredient-review-item input[name*="quantity"] {
+    flex: 0.5;
+    min-width: 60px;
+}
+
+.ingredient-review-item input[name*="unit"] {
+    flex: 1;
+    min-width: 80px;
+}
+
+.density-prompt {
+    flex: 1;
+    min-width: 120px;
+}
+
+.density-prompt input {
+    width: 100%;
+    padding: 12px;
+    box-sizing: border-box;
+}

--- a/app/templates/recipe_import_review.html
+++ b/app/templates/recipe_import_review.html
@@ -1,0 +1,68 @@
+<div class="container">
+    <h1>Review Imported Recipe</h1>
+    <p>Please review the extracted recipe details below. You can make corrections before saving.</p>
+
+    <form hx-post="/save_imported_recipe" hx-target="#content" hx-swap="innerHTML">
+        <!-- Recipe Name -->
+        <div class="form-group">
+            <label for="recipe_name">Recipe Name</label>
+            <input type="text" id="recipe_name" name="recipe_name" value="{{ recipe_data.recipe_name }}" required>
+        </div>
+
+        <!-- Instructions -->
+        <div class="form-group">
+            <label for="instructions">Instructions</label>
+            <textarea id="instructions" name="instructions" class="instructions-textarea" rows="15" required>{{ recipe_data.instructions }}</textarea>
+        </div>
+
+        <hr>
+
+        <!-- Ingredients -->
+        <h2>Ingredients</h2>
+        <div id="imported-ingredients-list">
+            {% for ingredient in recipe_data.ingredients %}
+            <div class="ingredient-review-item">
+                <select name="ingredient_id" onchange="toggleDensity(this, 'density-prompt-{{ loop.index }}')">
+                    <option value="_new_{{ ingredient.name }}">(New) {{ ingredient.name }}</option>
+                    <option value="" disabled>--- Existing Ingredients ---</option>
+                    {% for pantry_ing in all_ingredients %}
+                    <option value="{{ pantry_ing.id }}" {% if pantry_ing.id == ingredient.suggestion_id %}selected{% endif %}>
+                        {{ pantry_ing.name }}
+                    </option>
+                    {% endfor %}
+                </select>
+                <input type="text" name="ingredient_quantity" value="{{ ingredient.quantity }}" placeholder="Qty" required>
+                <input type="text" name="ingredient_unit" value="{{ ingredient.unit }}" placeholder="Unit">
+
+                {% if ingredient.needs_density_prompt %}
+                <div id="density-prompt-{{ loop.index }}" class="density-prompt" style="display: {% if not ingredient.suggestion_id %}block{% else %}none{% endif %};">
+                    <input type="number" step="any" name="density_{{ ingredient.name|replace(' ', '_') }}" placeholder="Density (g/ml)">
+                </div>
+                {% endif %}
+
+                <button type="button" onclick="this.parentElement.remove()" class="button-danger">Remove</button>
+            </div>
+            {% endfor %}
+        </div>
+
+        <div class="form-buttons">
+            <button type="submit" class="button-primary">Save Recipe</button>
+            <a href="/recipes" hx-get="/recipes" hx-target="#content" hx-swap="innerHTML" class="button">Cancel</a>
+        </div>
+    </form>
+
+    <div id="user-prompts"></div>
+</div>
+
+<script>
+function toggleDensity(selectElement, promptId) {
+    const promptDiv = document.getElementById(promptId);
+    if (promptDiv) {
+        if (selectElement.value.startsWith('_new_')) {
+            promptDiv.style.display = 'block';
+        } else {
+            promptDiv.style.display = 'none';
+        }
+    }
+}
+</script>

--- a/app/templates/recipe_manager.html
+++ b/app/templates/recipe_manager.html
@@ -11,6 +11,20 @@
 
 <hr>
 
+<!-- Import Recipe Form -->
+<div id="import-recipe-container">
+    <h2>Import Recipe from Text</h2>
+    <form hx-post="/import_recipe_process" hx-target="#content" hx-swap="innerHTML" hx-indicator="#import-indicator">
+        <textarea name="recipe_text" rows="10" placeholder="Paste your recipe here..." required></textarea>
+        <button type="submit" class="button-primary">Import Recipe</button>
+        <span id="import-indicator" class="htmx-indicator">
+            <i>Importing... This may take a moment.</i>
+        </span>
+    </form>
+</div>
+
+<hr>
+
 <!-- Filter Meals Form -->
 <h2>Filter Meals by Ingredients</h2>
 <form id="filter-form" hx-post="/filter_meals" hx-target="#meals-list-container" hx-swap="innerHTML">

--- a/jules-scratch/test_import.py
+++ b/jules-scratch/test_import.py
@@ -1,0 +1,185 @@
+import sqlite3
+import os
+import sys
+
+# Add the project root to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.database import init_db, seed_db, get_db_connection
+from app.units import parse_quantity, get_base_unit_type, get_base_unit
+
+# Mock Flask's request object for testing purposes
+class MockForm(dict):
+    def getlist(self, key):
+        return super().get(key, [])
+
+    def get(self, key, default=None):
+        value = super().get(key)
+        if isinstance(value, list) and value:
+            return value[0]
+        return value if value is not None else default
+
+class MockRequest:
+    def __init__(self, form_data):
+        self.form = MockForm(form_data)
+
+def save_imported_recipe_logic(request):
+    """
+    This function replicates the logic of the /save_imported_recipe route
+    for testing purposes, without the Flask-specific response objects.
+    """
+    conn = get_db_connection()
+    meal_id = None
+    try:
+        with conn:
+            recipe_name = request.form.get('recipe_name')
+            instructions = request.form.get('instructions')
+            if not recipe_name:
+                raise ValueError("Recipe name is required.")
+
+            cursor = conn.cursor()
+            cursor.execute("INSERT INTO meals (name, instructions) VALUES (?, ?)", (recipe_name, instructions))
+            meal_id = cursor.lastrowid
+
+            ingredient_ids = request.form.getlist('ingredient_id')
+            quantities = request.form.getlist('ingredient_quantity')
+            units = request.form.getlist('ingredient_unit')
+
+            for i in range(len(ingredient_ids)):
+                ing_id_val = ingredient_ids[i]
+                quantity_str = quantities[i]
+                unit = units[i].strip().lower()
+
+                try:
+                    quantity = parse_quantity(quantity_str)
+                except ValueError:
+                    continue
+
+                final_ingredient_id = None
+                if ing_id_val.startswith('_new_'):
+                    new_ing_name = ing_id_val[5:].strip().lower()
+                    existing = conn.execute("SELECT id FROM ingredients WHERE name = ?", (new_ing_name,)).fetchone()
+                    if existing:
+                        final_ingredient_id = existing['id']
+                    else:
+                        density_field_name = f"density_{new_ing_name.replace(' ', '_')}"
+                        density_str = request.form.get(density_field_name)
+
+                        base_unit_type = get_base_unit_type(unit) or 'count'
+                        base_unit = get_base_unit(base_unit_type)
+                        density_to_save = None
+
+                        if density_str:
+                            try:
+                                density_to_save = float(density_str)
+                                base_unit_type = 'mass'
+                                base_unit = 'g'
+                            except (ValueError, TypeError):
+                                density_to_save = None
+
+                        cursor.execute(
+                            "INSERT INTO ingredients (name, quantity, base_unit, base_unit_type, density_g_ml) VALUES (?, ?, ?, ?, ?)",
+                            (new_ing_name, 0, base_unit, base_unit_type, density_to_save)
+                        )
+                        final_ingredient_id = cursor.lastrowid
+                else:
+                    final_ingredient_id = int(ing_id_val)
+
+                if final_ingredient_id:
+                    conn.execute(
+                        "INSERT INTO meal_ingredients (meal_id, ingredient_id, quantity, unit) VALUES (?, ?, ?, ?)",
+                        (meal_id, final_ingredient_id, quantity, unit)
+                    )
+        return meal_id, None
+    except Exception as e:
+        print(f"Error in save_imported_recipe_logic: {e}")
+        return None, str(e)
+    finally:
+        if conn:
+            conn.close()
+
+def main():
+    DB_FILE = 'pantry.db'
+    print("--- Starting Test ---")
+
+    if os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+
+    init_db()
+    seed_db()
+    print("Database initialized and seeded.")
+
+    conn = get_db_connection()
+    conn.execute("INSERT INTO ingredients (name, quantity, base_unit, base_unit_type) VALUES (?, ?, ?, ?)", ('salt', 100, 'g', 'mass'))
+    conn.execute("INSERT INTO ingredients (name, quantity, base_unit, base_unit_type) VALUES (?, ?, ?, ?)", ('egg', 12, 'unit', 'count'))
+    conn.commit()
+    salt_id = conn.execute("SELECT id FROM ingredients WHERE name = 'salt'").fetchone()['id']
+    egg_id = conn.execute("SELECT id FROM ingredients WHERE name = 'egg'").fetchone()['id']
+    conn.close()
+    print(f"Pre-seeded ingredients: salt (id={salt_id}), egg (id={egg_id})")
+
+    # Mock form data, including density for new ingredients that need it
+    mock_form_data = {
+        'recipe_name': 'Chocolate Chip Cookies',
+        'instructions': 'Mix and bake.',
+        'ingredient_id': [
+            '_new_all-purpose flour',
+            '_new_baking soda', # This is a powder, let's give it a density
+            str(salt_id),
+            '_new_unsalted butter',
+            str(egg_id),
+        ],
+        'ingredient_quantity': ['1', '0.5', '0.5', '0.5', '1'],
+        'ingredient_unit': ['cup', 'tsp', 'tsp', 'cup', 'unit'],
+        'density_all-purpose_flour': '0.53', # g/ml
+        'density_baking_soda': '0.96', # g/ml
+        'density_unsalted_butter': '0.911' # g/ml
+    }
+    mock_request = MockRequest(mock_form_data)
+    print("Mock request data created with densities.")
+
+    print("Running save logic...")
+    new_meal_id, error = save_imported_recipe_logic(mock_request)
+
+    if error:
+        print(f"TEST FAILED: Logic returned an error: {error}")
+        return
+
+    print(f"Save logic executed. New meal ID: {new_meal_id}")
+
+    print("Verifying database state...")
+    conn = get_db_connection()
+
+    meal = conn.execute("SELECT * FROM meals WHERE id = ?", (new_meal_id,)).fetchone()
+    assert meal is not None, "FAIL: Meal was not created."
+    assert meal['name'] == 'Chocolate Chip Cookies', f"FAIL: Meal name is incorrect."
+    print("✅ Meal created successfully.")
+
+    meal_ingredients = conn.execute("SELECT * FROM meal_ingredients WHERE meal_id = ?", (new_meal_id,)).fetchall()
+    assert len(meal_ingredients) == 5, f"FAIL: Expected 5 meal ingredients, but found {len(meal_ingredients)}."
+    print(f"✅ Correct number of meal ingredients created ({len(meal_ingredients)}).")
+
+    # Verification for new ingredient with density
+    flour_ing = conn.execute("SELECT * FROM ingredients WHERE name = 'all-purpose flour'").fetchone()
+    assert flour_ing is not None, "FAIL: 'all-purpose flour' was not created."
+    assert flour_ing['base_unit_type'] == 'mass', "FAIL: Flour base_unit_type should be 'mass'."
+    assert flour_ing['base_unit'] == 'g', "FAIL: Flour base_unit should be 'g'."
+    assert flour_ing['density_g_ml'] == 0.53, f"FAIL: Flour density is incorrect. Got {flour_ing['density_g_ml']}"
+    print("✅ New ingredient 'all-purpose flour' created correctly with density.")
+
+    # Verification for another new ingredient with density
+    butter_ing = conn.execute("SELECT * FROM ingredients WHERE name = 'unsalted butter'").fetchone()
+    assert butter_ing is not None, "FAIL: 'unsalted butter' was not created."
+    assert butter_ing['density_g_ml'] == 0.911, f"FAIL: Butter density is incorrect. Got {butter_ing['density_g_ml']}"
+    print("✅ New ingredient 'unsalted butter' created correctly with density.")
+
+    # Verification for existing ingredient
+    salt_meal_ing = conn.execute("SELECT * FROM meal_ingredients WHERE meal_id = ? AND ingredient_id = ?", (new_meal_id, salt_id)).fetchone()
+    assert salt_meal_ing is not None, "FAIL: Salt not linked to meal."
+    print("✅ Existing ingredient 'salt' correctly linked to meal.")
+
+    conn.close()
+    print("\n--- TEST SUCCEEDED ---")
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 waitress
 thefuzz
 python-Levenshtein
+ollama


### PR DESCRIPTION
This feature introduces the capability for users to import recipes by pasting a block of text. It uses an Ollama multi-modal model to parse the text and extract the recipe name, ingredients, and instructions.

Key components of this feature include:
- A new `importer_service.py` module to communicate with the Ollama API.
- A new UI in the Recipe Manager to paste recipe text.
- A review screen (`recipe_import_review.html`) that allows users to correct the extracted data.
- Fuzzy matching to suggest existing ingredients from the user's pantry.
- A mechanism to prompt for and save the density (g/ml) for new ingredients that use mass or volume units, ensuring data integrity for unit conversions.
- A new route (`/save_imported_recipe`) to persist the final, reviewed recipe to the database.