### PR TITLE
fix: Handle None ingredients in recipe import process

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -640,6 +640,8 @@ def _process_recipe_ingredients_for_import(recipe_data, conn):
     all_ingredient_names = list(all_ingredients_map.keys())
 
     for ingredient in recipe_data.get('ingredients', []):
+        if not ingredient:
+            continue
         ingredient_name = ingredient.get('name', '').lower()
         best_match_record = None
 


### PR DESCRIPTION
The `_process_recipe_ingredients_for_import` function would crash with an `AttributeError` if the list of ingredients passed to it contained a `None` value. This occurred because the code did not anticipate non-dictionary items in the list.

This commit adds a check at the beginning of the ingredient processing loop to verify that the ingredient object is not `None`. If it is, the loop continues to the next item, preventing the crash and making the import process more resilient to malformed data.