### PR TITLE
Fix TypeError in generate_shopping_list

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1577,7 +1577,7 @@ def generate_shopping_list(meal_plan_id):
             display_unit = display_unit_row['unit'] if display_unit_row else ingredient['base_unit']
 
             # Convert needed quantity to display unit
-            display_quantity = convert_from_base(needed, ingredient['base_unit'], display_unit, ingredient_id, conn)
+            display_quantity = convert_units(needed, ingredient['base_unit'], display_unit, ingredient_id, conn)
 
             category = ingredient['category']
             if category not in shopping_list:


### PR DESCRIPTION
When adding a meal to the meal plan, the `generate_shopping_list` function was called. Inside this function, an attempt to convert ingredient quantities for the shopping list resulted in a `TypeError`.

The error was caused by calling the `convert_from_base` function with 5 arguments, but it only accepts up to 4. The code's intent was to convert a quantity from a known base unit to a specific display unit.

The correct function for this operation is `convert_units`, which accepts the number of arguments being passed and performs the intended conversion.

This change replaces the incorrect function call with the correct one, resolving the `TypeError`.